### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bs4==0.0.2
 lxml==5.3.0
 undetected-chromedriver==3.5.5
+setuptools


### PR DESCRIPTION
without setuptools users with python 3.12 and higher will get error:  ModuleNotFoundError: No module named 'distutils'
beginning from python 3.12 distutils were deleted from standard library